### PR TITLE
Fix dataset google doc URL

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -195,7 +195,7 @@
     </p>
 
     <p>
-      This project is <a href="https://github.com/c19k" target="_blank">maintained</a> and <a href="https://github.com/c19k/website" target="_blank">hosted</a> in <a href="https://github.com/" target="_blank">GitHub</a>. The dataset is managed with <a href="hhttps://docs.google.com/spreadsheets/d/e/2PACX-1vQU9eLCMT0XwWnoxV_LkyCkxMcPYO7z7ULdODoUFgcdzp48pgGpGrVZFXvraXYvUioVRsQgQDU_pQyI/pubhtml" target="_blank">Google Sheets</a>. <a href="https://github.com/geohacker/kerala" target="_blank">Kerala GeoJSON</a> is generously provided by <a href="https://github.com/geohacker" target="_blank">Sajjad Anwar</a>. Map is sponsored by the <a href="https://www.mapbox.com/community/" target="_blank">Mapbox Community team</a>.
+      This project is <a href="https://github.com/c19k" target="_blank">maintained</a> and <a href="https://github.com/c19k/website" target="_blank">hosted</a> in <a href="https://github.com/" target="_blank">GitHub</a>. The dataset is managed with <a href="https://docs.google.com/spreadsheets/d/e/2PACX-1vQU9eLCMT0XwWnoxV_LkyCkxMcPYO7z7ULdODoUFgcdzp48pgGpGrVZFXvraXYvUioVRsQgQDU_pQyI/pubhtml" target="_blank">Google Sheets</a>. <a href="https://github.com/geohacker/kerala" target="_blank">Kerala GeoJSON</a> is generously provided by <a href="https://github.com/geohacker" target="_blank">Sajjad Anwar</a>. Map is sponsored by the <a href="https://www.mapbox.com/community/" target="_blank">Mapbox Community team</a>.
     </p>
 
     <p>


### PR DESCRIPTION
There's typo with current url `hhttps://docs.google.com`. Fixed it to remove the extra `h` character.